### PR TITLE
Use --no-pretty when calling mypy

### DIFF
--- a/mypy_clean_slate/__init__.py
+++ b/mypy_clean_slate/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/mypy_clean_slate/main.py
+++ b/mypy_clean_slate/main.py
@@ -39,6 +39,7 @@ def generate_mypy_error_report(
         "mypy",
         f"{str(path_to_code)}",
         "--show-error-codes",
+        "--no-pretty",
         "--strict",
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mypy_clean_slate"
-version = "0.2.3"
+version = "0.2.4"
 description = "CLI tool for providing a clean slate for mypy usage within a project."
 authors = ["George Lenton <georgelenton@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
See issue for context: https://github.com/geo7/mypy_clean_slate/issues/88

Basically having pretty set in the mypy config breaks the current settings.