### PR TITLE
Provide --mypy_flags arg for passing custom mypy commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ usage: mypy_clean_slate [options]
 
 CLI tool for providing a clean slate for mypy usage within a project.
 
+Default expectation is to want to get a project into a state that it
+will pass mypy when run with `--strict`, if this isn't the case custom
+flags can be passed to mypy via the `--mypy_flags` argument.
+
 options:
   -h, --help            show this help message and exit
   -r, --generate_mypy_error_report
@@ -44,12 +48,13 @@ options:
                         Add "# type: ignore[<error-code>]" to suppress all raised mypy errors.
   -o MYPY_REPORT_OUTPUT, --mypy_report_output MYPY_REPORT_OUTPUT
                         File to save report output to (default is mypy_error_report.txt)
-
+  --mypy_flags MYPY_FLAGS
+                        Custom flags to pass to mypy (provide them as a single string, default is to use --strict)
 ```
 
 [comment]: # (CLI help split)
 
-See `./tests/test_mypy_clean_slate.py` for a basic, self contained, before/after example.
+See `./tests/test_mypy_clean_slate.py` for some examples with before/after.
 
 
 

--- a/mypy_clean_slate/__init__.py
+++ b/mypy_clean_slate/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.2.5"
+__version__ = "0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mypy_clean_slate"
-version = "0.2.5"
+version = "0.3.0"
 description = "CLI tool for providing a clean slate for mypy usage within a project."
 authors = ["George Lenton <georgelenton@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Previously the assumption was that a project would be updated to use --strict going forwards. This isn't always possible though, so a flag --mypy_flags is provided which enables the processing to be carried out for an explicit subset of mypy commands rather than the subset assumed by --strict.