### PR TITLE
fix: update logic checking whether mypy flags passed

### DIFF
--- a/mypy_clean_slate/__init__.py
+++ b/mypy_clean_slate/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/mypy_clean_slate/main.py
+++ b/mypy_clean_slate/main.py
@@ -35,7 +35,7 @@ def generate_mypy_error_report(
     mypy_flags: list[str],
 ) -> str:
     """Run mypy and generate report with errors."""
-    no_arguments_passed = (len(mypy_flags) == 1) and mypy_flags[0] == ""
+    no_arguments_passed = (len(mypy_flags) == 0) or ((len(mypy_flags) == 1) and mypy_flags[0] == "")
 
     if no_arguments_passed:
         # If no flags are passed we just assume we want to get things ready to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mypy_clean_slate"
-version = "0.3.0"
+version = "0.3.1"
 description = "CLI tool for providing a clean slate for mypy usage within a project."
 authors = ["George Lenton <georgelenton@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Logic added in f1405064bec2956e7690c2f5ab3e029007ed893f failed to check for the case of an empty list being passed as the mypy flags, resulting in _no_ flags being passed to mypy.

This update just ensures that if the mypy_flags var is '[]' (empty list) then mypy will be called with the default of --strict as before/expected.