### PR TITLE
Remove unused ignore statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ options:
                         Where code is that needs report generating for it.
   -a, --add_type_ignore
                         Add "# type: ignore[<error-code>]" to suppress all raised mypy errors.
+  --remove_unused       Remove unused instances of "# type: ignore[<error-code>]" if raised as an error by mypy.
   -o MYPY_REPORT_OUTPUT, --mypy_report_output MYPY_REPORT_OUTPUT
                         File to save report output to (default is mypy_error_report.txt)
   --mypy_flags MYPY_FLAGS

--- a/mypy_clean_slate/__init__.py
+++ b/mypy_clean_slate/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mypy_clean_slate"
-version = "0.3.1"
+version = "0.3.2"
 description = "CLI tool for providing a clean slate for mypy usage within a project."
 authors = ["George Lenton <georgelenton@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
If a line has had `type: ignore` added to it and the code changed mypy can give an error that the ignore is no longer needed. This change ensures that these can be removed automatically.