### PR TITLE
fix: Ensure that only two spaces are added before type ignore comments

### DIFF
--- a/mypy_clean_slate/__init__.py
+++ b/mypy_clean_slate/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/mypy_clean_slate/main.py
+++ b/mypy_clean_slate/main.py
@@ -151,6 +151,10 @@ def update_files(*, file_updates: list[FileUpdate]) -> None:
         file_lines = pathlib.Path(file_path).read_text(encoding="utf8").split("\n")
 
         python_code, python_comment = extract_code_comment(line=file_lines[line_number])
+        # In some cases it's possible for there to be multiple spaces added
+        # before '# type: ...' whereas we'd like to ensure only two spaces are
+        # added.
+        python_code = python_code.rstrip()
         mypy_ignore = f"# type: ignore[{error_codes}]"
 
         if python_comment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mypy_clean_slate"
-version = "0.3.2"
+version = "0.3.3"
 description = "CLI tool for providing a clean slate for mypy usage within a project."
 authors = ["George Lenton <georgelenton@gmail.com>"]
 license = "MIT"

--- a/tests/test_mypy_clean_slate.py
+++ b/tests/test_mypy_clean_slate.py
@@ -47,7 +47,7 @@ def add(*, arg_1, arg_2):  # type: ignore[no-untyped-def]
     return arg_1 + arg_2
 
 
-add(arg_1=1, arg_2="s")   # type: ignore[no-untyped-call] # inline comment.
+add(arg_1=1, arg_2="s")  # type: ignore[no-untyped-call] # inline comment.
 
 
 def useless_sub(*, arg_1: float, arg_2: Sequence):  # type: ignore[name-defined, no-untyped-def]


### PR DESCRIPTION
In some cases adding type ignore comments could result in multiple spaces before the type ignore comment, eg:

```
foo = "hi"
foo = 5  #
```
Would result in:
```
foo = "hi"
foo = 5    # type: ignore[assignment] #
```
This fix ensures the out put is instead:
```
foo = "hi"
foo = 5  # type: ignore[assignment] #
```